### PR TITLE
Add multiple mainstream news sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NPM Version](https://img.shields.io/npm/v/mcp-trends-hub)](https://www.npmjs.com/package/mcp-trends-hub)
 ![NPM License](https://img.shields.io/npm/l/mcp-trends-hub)
 
-基于 Model Context Protocol (MCP) 协议的纽约时报新闻服务
+基于 Model Context Protocol (MCP) 协议的多源新闻服务
 
 ## 示例效果
 
@@ -15,7 +15,7 @@
 
 ## ✨ 特性
 
-- 📊 **精选新闻** - 提供纽约时报的热点资讯
+- 📊 **精选新闻** - 提供纽约时报、华尔街见闻、BBC、华盛顿邮报、新华网、人民日报等热点资讯
 - 🔄 **实时更新** - 保持与源站同步的最新热点数据
 - 🧩 **MCP 协议支持** - 完全兼容 Model Context Protocol，轻松集成到 AI 应用
 - 🎨 **灵活定制** - 通过环境变量轻松调整返回字段
@@ -97,7 +97,12 @@ npx -y @smithery/cli install @baranwang/mcp-trends-hub --client claude
 <!-- tools-start -->
 | 工具名称 | 描述 |
 | --- | --- |
+| get-bbc-news | 获取 BBC 新闻最新国际要闻 |
 | get-nytimes-news | 获取纽约时报新闻，包含国际政治、经济金融、社会文化、科学技术及艺术评论的高质量英文或中文国际新闻资讯 |
+| get-people-news | 获取人民日报政治新闻 |
+| get-wallstreetcn-news | 获取华尔街见闻最新资讯 |
+| get-washington-post-news | 获取华盛顿邮报的国际新闻 |
+| get-xinhuanet-news | 获取新华网英文频道国际新闻 |
 
 
 <!-- tools-end -->

--- a/src/tools/bbc.ts
+++ b/src/tools/bbc.ts
@@ -1,0 +1,9 @@
+import { defineToolConfig, getRssItems } from '../utils';
+
+export default defineToolConfig({
+  name: 'get-bbc-news',
+  description: '获取 BBC 新闻最新国际要闻',
+  func: async () => {
+    return getRssItems('https://feeds.bbci.co.uk/news/world/rss.xml');
+  },
+});

--- a/src/tools/people.ts
+++ b/src/tools/people.ts
@@ -1,0 +1,9 @@
+import { defineToolConfig, getRssItems } from '../utils';
+
+export default defineToolConfig({
+  name: 'get-people-news',
+  description: '获取人民日报政治新闻',
+  func: async () => {
+    return getRssItems('http://www.people.com.cn/rss/politics.xml');
+  },
+});

--- a/src/tools/wallstreetcn.ts
+++ b/src/tools/wallstreetcn.ts
@@ -1,0 +1,9 @@
+import { defineToolConfig, getRssItems } from '../utils';
+
+export default defineToolConfig({
+  name: 'get-wallstreetcn-news',
+  description: '获取华尔街见闻最新资讯',
+  func: async () => {
+    return getRssItems('https://rsshub.app/wallstreetcn/news');
+  },
+});

--- a/src/tools/washingtonpost.ts
+++ b/src/tools/washingtonpost.ts
@@ -1,0 +1,9 @@
+import { defineToolConfig, getRssItems } from '../utils';
+
+export default defineToolConfig({
+  name: 'get-washington-post-news',
+  description: '获取华盛顿邮报的国际新闻',
+  func: async () => {
+    return getRssItems('https://feeds.washingtonpost.com/rss/world');
+  },
+});

--- a/src/tools/xinhuanet.ts
+++ b/src/tools/xinhuanet.ts
@@ -1,0 +1,9 @@
+import { defineToolConfig, getRssItems } from '../utils';
+
+export default defineToolConfig({
+  name: 'get-xinhuanet-news',
+  description: '获取新华网英文频道国际新闻',
+  func: async () => {
+    return getRssItems('https://english.news.cn/rss/worldrss.xml');
+  },
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -25,13 +25,23 @@ describe('MCP 工具测试', async () => {
     expect(toolsResponse).toBeDefined();
     expect(toolsResponse).toHaveProperty('tools');
     expect(toolsResponse.tools).toBeInstanceOf(Array);
-    expect(toolsResponse.tools).toHaveLength(1);
-    expect(toolsResponse.tools[0].name).toBe('get-nytimes-news');
+    expect(toolsResponse.tools).toHaveLength(6);
+    const toolNames = toolsResponse.tools.map((t) => t.name);
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        'get-nytimes-news',
+        'get-wallstreetcn-news',
+        'get-bbc-news',
+        'get-washington-post-news',
+        'get-xinhuanet-news',
+        'get-people-news',
+      ]),
+    );
   });
 
-  test('应能调用纽约时报工具', async () => {
+  test('应能调用 BBC 新闻工具', async () => {
     const result = await client.callTool({
-      name: 'get-nytimes-news',
+      name: 'get-bbc-news',
     });
     expect(result).toBeDefined();
     expect(result).toHaveProperty('content');


### PR DESCRIPTION
## Summary
- add BBC, 华尔街见闻, 华盛顿邮报, 新华网和人民日报工具
- update README tools list and description
- check for all tools and call BBC in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847be89fba4832f971d8b6e5379d1c6