### PR TITLE
Add Xueqiu & SeekingAlpha trending tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,11 @@ npx -y @smithery/cli install @baranwang/mcp-trends-hub --client claude
 | get-bbc-news | 获取 BBC 新闻最新国际要闻 |
 | get-nytimes-news | 获取纽约时报新闻，包含国际政治、经济金融、社会文化、科学技术及艺术评论的高质量英文或中文国际新闻资讯 |
 | get-people-news | 获取人民日报政治新闻 |
+| get-seekingalpha-news | 获取 Seeking Alpha 热点新闻 |
 | get-wallstreetcn-news | 获取华尔街见闻最新资讯 |
 | get-washington-post-news | 获取华盛顿邮报的国际新闻 |
 | get-xinhuanet-news | 获取新华网英文频道国际新闻 |
+| get-xueqiu-hot-posts | 获取雪球热门帖子 |
 
 
 <!-- tools-end -->

--- a/src/tools/seekingalpha.ts
+++ b/src/tools/seekingalpha.ts
@@ -1,0 +1,9 @@
+import { defineToolConfig, getRssItems } from '../utils';
+
+export default defineToolConfig({
+  name: 'get-seekingalpha-news',
+  description: '获取 Seeking Alpha 热点新闻',
+  func: async () => {
+    return getRssItems('https://seekingalpha.com/market_currents.xml');
+  },
+});

--- a/src/tools/xueqiu.ts
+++ b/src/tools/xueqiu.ts
@@ -1,0 +1,9 @@
+import { defineToolConfig, getRssItems } from '../utils';
+
+export default defineToolConfig({
+  name: 'get-xueqiu-hot-posts',
+  description: '获取雪球热门帖子',
+  func: async () => {
+    return getRssItems('https://rsshub.app/xueqiu/hots');
+  },
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -25,7 +25,7 @@ describe('MCP 工具测试', async () => {
     expect(toolsResponse).toBeDefined();
     expect(toolsResponse).toHaveProperty('tools');
     expect(toolsResponse.tools).toBeInstanceOf(Array);
-    expect(toolsResponse.tools).toHaveLength(6);
+    expect(toolsResponse.tools).toHaveLength(8);
     const toolNames = toolsResponse.tools.map((t) => t.name);
     expect(toolNames).toEqual(
       expect.arrayContaining([
@@ -35,6 +35,8 @@ describe('MCP 工具测试', async () => {
         'get-washington-post-news',
         'get-xinhuanet-news',
         'get-people-news',
+        'get-seekingalpha-news',
+        'get-xueqiu-hot-posts',
       ]),
     );
   });
@@ -42,6 +44,16 @@ describe('MCP 工具测试', async () => {
   test('应能调用 BBC 新闻工具', async () => {
     const result = await client.callTool({
       name: 'get-bbc-news',
+    });
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty('content');
+    expect(result.content).toBeInstanceOf(Array);
+    expect(result.content).not.toHaveLength(0);
+  });
+
+  test('应能调用 Seeking Alpha 新闻工具', async () => {
+    const result = await client.callTool({
+      name: 'get-seekingalpha-news',
     });
     expect(result).toBeDefined();
     expect(result).toHaveProperty('content');


### PR DESCRIPTION
## Summary
- add Xueqiu and Seeking Alpha trending tools
- update README tool list
- update tests for new tools

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6847dacab780832fa4156d6929de3f0e